### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+frontend/build/
+backend/database.sqlite
+backend/node_modules/
+frontend/node_modules/
+.env
+frontend/.env
+backend/.env

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ npm run build
 # Deploy the 'build' folder to your web server
 ```
 
+### GitHub Pages
+You can host the frontend directly on GitHub Pages:
+
+```bash
+cd frontend
+npm run deploy
+```
+
+The `deploy` script builds the app and publishes the `build` folder to the
+`gh-pages` branch. Make sure to update the `homepage` field in
+`frontend/package.json` with your GitHub username before running the command.
+
 ### Backend (Node.js)
 ```bash
 cd backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://YOUR_GITHUB_USERNAME.github.io/task-management-system",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -18,6 +19,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -37,5 +40,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  }
+  ,
+  "devDependencies": {
+    "gh-pages": "^5.0.0"
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
 function App() {
   const [activities, setActivities] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -8,7 +10,7 @@ function App() {
 
   // Load data
   useEffect(() => {
-    fetch('http://localhost:3001/api/activities')
+    fetch(`${API_URL}/api/activities`)
       .then(response => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
@@ -44,7 +46,7 @@ function App() {
       tags: []
     };
 
-    fetch('http://localhost:3001/api/activities', {
+    fetch(`${API_URL}/api/activities`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(newTask)
@@ -63,7 +65,7 @@ function App() {
     const activity = activities.find(a => a.id === id);
     const updatedActivity = { ...activity, [field]: value };
 
-    fetch(`http://localhost:3001/api/activities/${id}`, {
+    fetch(`${API_URL}/api/activities/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(updatedActivity)
@@ -81,7 +83,7 @@ function App() {
   const deleteTask = (id) => {
     if (!window.confirm('Are you sure you want to delete this task?')) return;
 
-    fetch(`http://localhost:3001/api/activities/${id}`, { method: 'DELETE' })
+    fetch(`${API_URL}/api/activities/${id}`, { method: 'DELETE' })
       .then(() => {
         setActivities(prev => prev.filter(a => a.id !== id));
       })

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('shows loading indicator', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const loadingElement = screen.getByText(/Loading activities.../i);
+  expect(loadingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add GitHub Pages deploy script and homepage setting
- support configurable API URL in the React app
- update failing test and add gh-pages dev dependency
- document how to deploy frontend to GitHub Pages
- add .gitignore

## Testing
- `npm test --silent -- --watchAll=false` in `frontend`
- `npm test --silent -- --passWithNoTests` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_684576f819848321ae4318cccefcff06