### PR TITLE
Enable GitHub Pages deployment (conflict-free)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+frontend/build/
+backend/database.sqlite
+backend/node_modules/
+frontend/node_modules/
+.env
+frontend/.env
+backend/.env

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ npm run build
 # Deploy the 'build' folder to your web server
 ```
 
+### GitHub Pages
+You can host the frontend directly on GitHub Pages:
+
+```bash
+cd frontend
+npm run deploy
+```
+
+The `deploy` script builds the app and publishes the `build` folder to the
+`gh-pages` branch. Make sure to update the `homepage` field in
+`frontend/package.json` with your GitHub username before running the command.
+
 ### Backend (Node.js)
 ```bash
 cd backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://ViranjPatel.github.io/task-management-system",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -18,6 +19,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -37,5 +40,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "gh-pages": "^5.0.0"
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
 function App() {
   const [activities, setActivities] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -8,7 +10,7 @@ function App() {
 
   // Load data
   useEffect(() => {
-    fetch('http://localhost:3001/api/activities')
+    fetch(`${API_URL}/api/activities`)
       .then(response => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
@@ -44,7 +46,7 @@ function App() {
       tags: []
     };
 
-    fetch('http://localhost:3001/api/activities', {
+    fetch(`${API_URL}/api/activities`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(newTask)
@@ -63,7 +65,7 @@ function App() {
     const activity = activities.find(a => a.id === id);
     const updatedActivity = { ...activity, [field]: value };
 
-    fetch(`http://localhost:3001/api/activities/${id}`, {
+    fetch(`${API_URL}/api/activities/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(updatedActivity)
@@ -81,7 +83,7 @@ function App() {
   const deleteTask = (id) => {
     if (!window.confirm('Are you sure you want to delete this task?')) return;
 
-    fetch(`http://localhost:3001/api/activities/${id}`, { method: 'DELETE' })
+    fetch(`${API_URL}/api/activities/${id}`, { method: 'DELETE' })
       .then(() => {
         setActivities(prev => prev.filter(a => a.id !== id));
       })


### PR DESCRIPTION
## Summary
- Add GitHub Pages deploy script and homepage setting
- Support configurable API URL in the React app
- Add .gitignore file
- Document how to deploy frontend to GitHub Pages

This PR contains the same changes as PR #5 but is based on the latest main branch and has been updated to avoid conflicts. The GitHub username in the homepage URL has been set to "ViranjPatel" for proper deployment.

## Testing
- Tests should pass with `npm test --silent -- --watchAll=false` in `frontend`
- The API URL is configurable via the REACT_APP_API_URL environment variable