### PR TITLE
Fix AG Grid module registration

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+
+// Register AG Grid Modules
+ModuleRegistry.registerModules([AllCommunityModule]);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- register `AllCommunityModule` in the React entry point so AG Grid can initialize

## Testing
- `npm test --silent` in `backend` *(fails: No tests found)*
- `npm test --silent` in `frontend` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68467b2aae6c8321a72949ead5e7d6eb